### PR TITLE
@exclude on show_dilemma

### DIFF
--- a/autoclose=1.user.js
+++ b/autoclose=1.user.js
@@ -4,9 +4,10 @@
 // @version      0.1
 // @description  try to take over the world!
 // @author       9003
-//@match         *://*/*autoclose=1 
+// @match         *://*/*autoclose=1
+// @exclude      https://www.nationstates.net/*page=show_dilemma*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=nationstates.net// 
-//@grant        none
+// @grant        none
 // ==/UserScript==
 
 (function() {


### PR DESCRIPTION
Added an @exclude directive that matches the page=show_dilemma to prevent autoclose from closing that link when using the new gotIssues.